### PR TITLE
Bump supported node versions to reflect currently released version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Zx.MYS <manyoushen@gmail.com>",
   "main": "lib/Twemoji/index.js",
   "engines": {
-    "node": ">=5.0 <6",
+    "node": ">=5.0 <8",
     "npm": ">=3.3 <4"
   },
   "repository": {


### PR DESCRIPTION
@ZxMYS 

When using [Yarn](yarnpkg.com) as my dependency manager, I'm running into this error when using Node 6.5 or Node 7.0.

![screen shot 2016-11-07 at 5 07 46 pm](https://cloud.githubusercontent.com/assets/5208/20080167/c86f0d2a-a50d-11e6-8bb3-9176d1106da8.png)

I'm not aware of any incompatibilities with these Node versions, so this PR simply bumps the supported versions in the package.json `engines` configuration option.