### PR TITLE
Change main element from div to span

### DIFF
--- a/src/Twemoji/index.js
+++ b/src/Twemoji/index.js
@@ -56,7 +56,7 @@ export default class Twemoji extends React.Component {
         </>);
     } else {
       delete other.options;
-      return <div ref={this.rootRef} {...other}>{children}</div>;
+      return <span ref={this.rootRef} {...other}>{children}</span>;
     }
   }
 }


### PR DESCRIPTION
When using Twemoji inside a `<p>`, React returns the error `validateDOMNesting(...): <div> cannot appear as a descendant of <p>`, this cause bugs with javascript and css because of extra rendering tags.