### PR TITLE
Update react dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "twemoji": "13.1.0"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2"
+    "react": ">=16.4.2"
   }
 }


### PR DESCRIPTION
also remove peer dependency on the `react-dom`, because why? 🤷‍♂️