### PR TITLE
chore: update twemoji version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.7.2",
-    "twemoji": "14.0.1"
+    "twemoji": "14.0.2"
   },
   "peerDependencies": {
     "react": ">=16.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4798,9 +4798,10 @@ twemoji-parser@14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-14.0.0.tgz#13dabcb6d3a261d9efbf58a1666b182033bf2b62"
 
-twemoji@14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.1.tgz#0640887ef149403ae577081cbc2480a026e55ed6"
+twemoji@14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-14.0.2.tgz#c53adb01dab22bf4870f648ca8cc347ce99ee37e"
+  integrity sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"


### PR DESCRIPTION
MaxCDN is shut down right now, so in the meanwhile use a different CDN or download the assets