### PR TITLE
Fix: Twemoji Base URL

### DIFF
--- a/src/Twemoji/index.js
+++ b/src/Twemoji/index.js
@@ -29,11 +29,17 @@ export default class Twemoji extends React.Component {
     if (noWrapper) {
       for (const i in this.childrenRefs) {
         const node = this.childrenRefs[i].current;
-        twemoji.parse(node, this.props.options);
+        twemoji.parse(node, {
+          base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
+          ...this.props.options,
+        });
       }
     } else {
       const node = this.rootRef.current;
-      twemoji.parse(node, this.props.options);
+      twemoji.parse(node, {
+        base: 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/',
+        ...this.props.options,
+      });
     }
   }
 
@@ -48,25 +54,30 @@ export default class Twemoji extends React.Component {
   }
 
   render() {
-    const { children, noWrapper, tag,  ...other } = this.props;
+    const { children, noWrapper, tag, ...other } = this.props;
     if (noWrapper) {
       return (
         <>
-        {
-          React.Children.map(children, (c, i) => {
+          {React.Children.map(children, (c, i) => {
             if (typeof c === 'string') {
               // eslint-disable-next-line no-console
-              console.warn(`Twemoji can't parse string child when noWrapper is set. Skipping child "${c}"`);
+              console.warn(
+                `Twemoji can't parse string child when noWrapper is set. Skipping child '${c}'`
+              );
               return c;
             }
             this.childrenRefs[i] = this.childrenRefs[i] || React.createRef();
             return React.cloneElement(c, { ref: this.childrenRefs[i] });
-          })
-        }
-        </>);
+          })}
+        </>
+      );
     } else {
       delete other.options;
-      return React.createElement(tag, { ref: this.rootRef, ...other }, children);
+      return React.createElement(
+        tag,
+        { ref: this.rootRef, ...other },
+        children
+      );
     }
   }
 }


### PR DESCRIPTION
Since old maxcdn has shut down and no longer works, this is quick fix for changing baseUrl of twemoji parser to render emojis

Current one renders default browser emojis, because of maxcdn issue
<img width="162" alt="image" src="https://github.com/user-attachments/assets/bb1532e7-bf70-4d36-83c4-bb83a6b6a1cf">

My updated one renders twemoji
<img width="186" alt="image" src="https://github.com/user-attachments/assets/875072a0-499a-471a-a7b6-cadfd92648cb">
